### PR TITLE
Fix SaveTimer keeping dedicated server instances open after shutdown

### DIFF
--- a/common/src/main/java/dev/the_fireplace/lib/lazyio/SaveTimerImpl.java
+++ b/common/src/main/java/dev/the_fireplace/lib/lazyio/SaveTimerImpl.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class SaveTimerImpl implements SaveTimer
 {
     private final Map<Short, Set<Runnable>> saveIntervalFunctions = new ConcurrentHashMap<>();
-    private Timer timer = new Timer();
+    private Timer timer = new Timer("FireplaceLib-SaveTimer", true);
     private final ExecutionManager executionManager;
 
     @Inject
@@ -76,7 +76,7 @@ public final class SaveTimerImpl implements SaveTimer
 
     @Override
     public void resetTimer() {
-        timer = new Timer();
+        timer = new Timer("FireplaceLib-SaveTimer", true);
     }
 
     private void saveAll() {


### PR DESCRIPTION
Make the Timers that SaveTimerImpl uses create daemon threads, so the server process close doesn't wait for them to exit. I'm not entirely sure why the existing .cancel() doesn't work - possibly when resetTimer is called they still hang around until a GC run?

Added a friendly name, so other people staring at thread lists can identify what the ominous "Timer-3" threads are.

![The timer being kept around after the server exits](https://github.com/The-Fireplace-Minecraft-Mods/Fireplace-Lib/assets/1138417/12a02b68-361b-4b8a-b037-31786982ecff)
